### PR TITLE
Fix variable name typo

### DIFF
--- a/airmar_reader.py
+++ b/airmar_reader.py
@@ -321,7 +321,7 @@ def publish_discovery_config(client):
     )
 
     # GPS lon
-    gps_lot_config = {
+    gps_lon_config = {
         "name": "GPS longitude",
         # "device_class": "timestamp",
         "unique_id": "gps_lon",
@@ -338,7 +338,7 @@ def publish_discovery_config(client):
     }
     client.publish(
         f"{discovery_prefix}/sensor/{client_id}/lon/config",
-        json.dumps(gps_lot_config),
+        json.dumps(gps_lon_config),
         retain=True,
     )
 


### PR DESCRIPTION
## Summary
- correct variable `gps_lot_config` to `gps_lon_config`

## Testing
- `python3 -m py_compile airmar_reader.py`

------
https://chatgpt.com/codex/tasks/task_e_6840401e37c883269152f7cb208a8b5e