### PR TITLE
Fix on_connect logging error

### DIFF
--- a/airmar_reader.py
+++ b/airmar_reader.py
@@ -651,7 +651,7 @@ def connect_mqtt():
         if rc == 0:
             logging.info("Connected to MQTT Broker")
         else:
-            logging.error("Connection failed:", rc)
+            logging.error("Connection failed: %s", rc)
             exit(0)
 
     client = mqtt_client.Client(client_id)


### PR DESCRIPTION
## Summary
- fix logging call for failed MQTT connection

## Testing
- `python3 -m py_compile airmar_reader.py`
- run Python snippet to ensure no `TypeError` is raised when logging failure

------
https://chatgpt.com/codex/tasks/task_e_68403ff7d1008326b0d9d72e696ab084