### PR TITLE
Fix heading typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Python script that runs on any linux machine, it uses USB to listen to the airmar and parses that data and pushes it to MQTT. If you have home assistant auto discovery will work for this.
 <img width="472" alt="image" src="https://github.com/bruvv/Airmar-150WX-Sensor-Data/assets/3063928/94f61b3d-7de3-4934-a6fc-39c6f0911f11">
 
-## Requirments
+## Requirements
 
 sudo apt install python3-nmea2 python3-serial python3-paho-mqtt
 


### PR DESCRIPTION
## Summary
- fix typo in README heading from `Requirments` to `Requirements`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68403feb215883269505baf7f527ec55